### PR TITLE
Numeric ops interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ var m = IntegerVariable.makeIntVariableWithBounds('m', p, -100, 100);
 var intercept = IntegerVariable.makeIntVariableWithBounds('intercept', p, -100, 100);
 ```
 
+Craftjs can also create constants:
+```javascript
+var floatConstant = FloatVariable.makeFloatConstant('flConst', p, 0.5);
+var intConstant = IntegerVariable.makeIntConstant('intConst', p, 7);
+```
+
 Now that we've got our independent variables figured out, lets add constraints.
 Quad is constrained to be the a squared plus b, so let us tell Craftjs that.
 ```javascript
@@ -83,22 +89,31 @@ are:
 FloatVariable.add(a, b) --> a + b
 FloatVariable.subtract(a, b) --> a - b
 FloatVariable.multiply(a, b) --> a * b
-FloatVariable.multiplyIntervalByConstant(a, k) --> a * k (where k is a Number)
 FloatVariable.divide(a, b) --> a / b
 FloatVariable.pow(a, exponent) --> a ^ exponent (where exponent is a Number)
 ```
+
 For Integers, the same sorts of ops look like:
 ```
 IntegerVariable.add(a, b) --> a + b
 IntegerVariable.subtract(a, b) --> a - b
 IntegerVariable.multiply(a, b) --> a * b
-IntegerVariable.multiplyIntervalByConstant(a, k) --> a * k (where k is a Number)
 IntegerVariable.divide(a, b) --> a / b
 IntegerVariable.pow(a, exponent) --> a ^ exponent (where exponent is a Number)
 ```
-Note that, for integers, Craftjs will throw errors if `k` or `exponent` are
-floating point.  If these need to be floats, use the operations in `FloatVariable`
-instead.
+
+For both these cases, `a` and `b` can be variables or plain Javascript numbers.
+```javascript
+var example = FloatVariable.makeFloatVariableWithBounds('ex', p, 0, 1);
+FloatVariable.add(1, example);
+FloatVariable.add(example, 1);
+```
+Both of the above cases are valid.  Craftjs will promote numbers to constants
+automagically.  This is also true for `IntegerVariables`.
+
+Note that, for integers, Craftjs will throw errors if any provided argument is
+a floating point number.  If you need to use floats, use the operations in FloatVariable
+instead.  Future work will allow to constrain floating point operations to the integer space.
 
 If you're familiar with reverse polish syntax, this probably rings a few bells.
 It's also important to note that Craftjs does not enforce order of operations--
@@ -113,10 +128,12 @@ quad.mustBeContainedInRange(10, 20);
 Craftjs has some other constraints to add to `FloatVariable` or `IntegerVariable`s:
 ```
 .mustBeContainedIn(low, high) --> variable must be within the specified range
-.mustEqual(Number Or Variable) --> variable must equal the provided Number
-.mustBeLessThanOrEqualTo(Number Or Variable) --> variable must be less than or equal to the provided Number
-.mustBeGreaterThanOrEqualTo(Number Or Variable) --> variable must be greater than or equal to the provided number
+.mustEqual(Number Or Variable) --> variable must equal the provided Number or Variable
+.mustBeLessThanOrEqualTo(Number Or Variable) --> variable must be less than or equal to the provided Number or Variable
+.mustBeGreaterThanOrEqualTo(Number Or Variable) --> variable must be greater than or equal to the provided number or Variable
 ```
+with the usual caveat of Craftjs having undefined behavior if you mix variable types (i.e. `FloatVariable.mustEqual(IntegerVariable)`
+or the other way around)
 
 Now that we've set up the CSP, we can start getting solutions to it.  Craftjs gets one
 solution to the CSP at a time, and does not make any promises about not returning the same solution twice.

--- a/README.md
+++ b/README.md
@@ -174,5 +174,5 @@ the configuration phase.  Craftjs does not do this, and uses `mustBeContainedIn(
 Take care when assigning variable names.  The names "a", "b", "sum", "difference", "product", "quotient" and "power" may get overwritten by the solver and end up getting assigned to the wrong constraints.  The more descriptive a name is, the more useful it is overall.  The internal variable representation will get tweaked in a future release to prevent this from happening.
 
 #### other
-Craftjs is very much in development.  This is an alpha build (0.21, at time of writing this disclamer), and may be bug-ridden.
+Craftjs is very much in development.  This is an alpha build (0.22, at time of writing this disclamer), and may be bug-ridden.
 Please, add an issue tag for any bugs you find.

--- a/js/modules/integerScalarArithmeticConstraints.js
+++ b/js/modules/integerScalarArithmeticConstraints.js
@@ -137,6 +137,7 @@ define(['inheritance', 'integerInterval', 'mathUtil', 'scalarArithmeticConstrain
     });
     intConstraints.ProductConstraint = IntProductConstraint;
 
+    /*
     var IntConstantProductConstraint = ScalarArithmeticConstraints.ConstantProductConstraint.extend({
         init : function(product, a, k){
             this._super(product, a, k);
@@ -176,7 +177,8 @@ define(['inheritance', 'integerInterval', 'mathUtil', 'scalarArithmeticConstrain
         },
     });
     intConstraints.ConstantProductConstraint = IntConstantProductConstraint;
-
+    */
+   
     var IntQuoitentConstraint = ScalarArithmeticConstraints.QuotientConstraint.extend({
         init : function(quotient, a, b){
             this._super(quotient, a, b);

--- a/js/modules/scalarArithmeticConstraints.js
+++ b/js/modules/scalarArithmeticConstraints.js
@@ -115,6 +115,7 @@ define(['inheritance', 'constraint', 'interval', 'mathUtil'], function(Inheritan
     });
     constraints.ProductConstraint = ProductConstraint;
 
+    /*
     var ConstantProductConstraint = Constraint.extend({
         init : function(product, a, k){
             this._super(product.csp);
@@ -139,7 +140,7 @@ define(['inheritance', 'constraint', 'interval', 'mathUtil'], function(Inheritan
                 //number to inf * 0 = 0.
                 //So, under practical cases, we've already narrowed the product to 0 at this point,
                 //the value of a doesn't matter.
-                //FIXME: can't wait to spend 4 hours finding the bug this introduces.
+                //... still waiting for the bug that I'm sure this introduced to rear its head
                 if(this.k !== 0){
                     this.a.narrowTo(Interval.multiplyIntervalByConstant(this.product.value(), (1 / this.k)), fail);
                 }
@@ -151,6 +152,7 @@ define(['inheritance', 'constraint', 'interval', 'mathUtil'], function(Inheritan
         }
     });
     constraints.ConstantProductConstraint = ConstantProductConstraint;
+    */
 
     var QuoitentConstraint = Constraint.extend({
         init : function(quotient, a, b){

--- a/js/test/integerScalarArithmeticTests.js
+++ b/js/test/integerScalarArithmeticTests.js
@@ -146,6 +146,62 @@ define(['inheritance', 'csp', 'floatVariable', 'integerVariable', 'mathUtil', 'i
             assertUnique(b, 1);
         });
 
+        it("Integer Sum Test w/ constant A term", function(){
+            console.log("======================================");
+            console.log("Sum Test w/ constant A term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = 1;
+            var b = IntegerVariable.makeIntVariableWithBounds("b", p, 0, 2);
+            var sum = IntegerVariable.add(a, b);
+            b.mustEqual(1);
+
+            p.testConsistency();
+            assertUnique(sum, 2);
+        });
+
+        it("Integer Sum B Term Test w/ constant A term", function(){
+            console.log("======================================");
+            console.log("Sum B Term Test w/ constant A term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = 1;
+            var b = IntegerVariable.makeIntVariableWithBounds("b", p, 0, 2);
+            var sum = IntegerVariable.add(a, b);
+            sum.mustEqual(2);
+
+            p.testConsistency();
+            assertUnique(b, 1);
+        });
+
+        it("Integer Sum Test w/ constant B term", function(){
+            console.log("======================================");
+            console.log("Sum Test w/ constant B term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 2);
+            var b = 1;
+            var sum = IntegerVariable.add(a, b);
+            a.mustEqual(1);
+
+            p.testConsistency();
+            assertUnique(sum, 2);
+        });
+
+        it("Integer Sum A term Test w/ constant B term", function(){
+            console.log("======================================");
+            console.log("Sum A Term Test w/ constant B term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 2);
+            var b = 1;
+            var sum = IntegerVariable.add(a, b);
+            sum.mustEqual(2);
+
+            p.testConsistency();
+            assertUnique(a, 1);
+        });
+
         it("Integer Difference Test", function(){
             console.log("======================================");
             console.log("Difference Test");
@@ -189,6 +245,62 @@ define(['inheritance', 'csp', 'floatVariable', 'integerVariable', 'mathUtil', 'i
 
             p.testConsistency();
             assertUnique(b, 1);
+        });
+
+        it("Integer Difference Test w/ constant A term", function(){
+            console.log("======================================");
+            console.log("Difference Test w/ constant A term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = 2;
+            var b = IntegerVariable.makeIntVariableWithBounds("b", p, 0, 2);
+            var difference = IntegerVariable.subtract(a, b);
+            b.mustEqual(1);
+
+            p.testConsistency();
+            assertUnique(difference, 1);
+        });
+
+        it("Integer Difference B Term Test w/ constant A term", function(){
+            console.log("======================================");
+            console.log("Difference B Term Test w/ constant A term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = 2;
+            var b = IntegerVariable.makeIntVariableWithBounds("b", p, 0, 2);
+            var difference = IntegerVariable.subtract(a, b);
+            difference.mustEqual(1);
+
+            p.testConsistency();
+            assertUnique(b, 1);
+        });
+
+        it("Integer Difference Test w/ constant B term", function(){
+            console.log("======================================");
+            console.log("Difference Test w/ constant B term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 2);
+            var b = 1;
+            var difference = IntegerVariable.subtract(a, b);
+            a.mustEqual(2);
+
+            p.testConsistency();
+            assertUnique(difference, 1);
+        });
+
+        it("Integer Difference A Term Test w/ constant B term", function(){
+            console.log("======================================");
+            console.log("Difference A Term Test w/ constant B term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 2);
+            var b = 1;
+            var difference = IntegerVariable.subtract(a, b);
+            difference.mustEqual(1);
+
+            p.testConsistency();
+            assertUnique(a, 2);
         });
 
         it("Integer Product Test", function(){
@@ -245,7 +357,7 @@ define(['inheritance', 'csp', 'floatVariable', 'integerVariable', 'mathUtil', 'i
             var p = new CSP();
             var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 2);
             var k = 4;
-            var product = IntegerVariable.multiplyVariableByConstant(a, k);
+            var product = IntegerVariable.multiply(a, k);
 
             a.mustEqual(1);
             p.testConsistency();
@@ -259,7 +371,35 @@ define(['inheritance', 'csp', 'floatVariable', 'integerVariable', 'mathUtil', 'i
             var p = new CSP();
             var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 2);
             var k = 4;
-            var product = IntegerVariable.multiplyVariableByConstant(a, k);
+            var product = IntegerVariable.multiply(a, k);
+            product.mustEqual(8);
+
+            p.testConsistency();
+            assertUnique(a, 2);
+        });
+
+        it("Integer Const Product Test, reversed arguments", function(){
+            console.log("======================================");
+            console.log("Const Product Test, reversed arguments");
+            console.log("======================================");
+            var p = new CSP();
+            var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 2);
+            var k = 4;
+            var product = IntegerVariable.multiply(k, a);
+
+            a.mustEqual(1);
+            p.testConsistency();
+            assertUnique(product, 4);
+        });
+
+        it("Integer Const Product A Term Test, reversed arguments", function(){
+            console.log("======================================");
+            console.log("Const Product A Term Test, reversed arguments");
+            console.log("======================================");
+            var p = new CSP();
+            var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 2);
+            var k = 4;
+            var product = IntegerVariable.multiply(k, a);
             product.mustEqual(8);
 
             p.testConsistency();
@@ -316,12 +456,12 @@ define(['inheritance', 'csp', 'floatVariable', 'integerVariable', 'mathUtil', 'i
 
         it("Integer Const Product k=0 test", function(){
             console.log("======================================");
-            console.log("Const Product A Term Test");
+            console.log("Const Product k=0 Test");
             console.log("======================================");
             var p = new CSP();
             var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 2);
             var k = 0;
-            var product = IntegerVariable.multiplyVariableByConstant(a, k);
+            var product = IntegerVariable.multiply(a, k);
             a.mustEqual(2);
 
             p.testConsistency();
@@ -330,12 +470,40 @@ define(['inheritance', 'csp', 'floatVariable', 'integerVariable', 'mathUtil', 'i
 
         it("Integer Const Product k=0 A Term test", function(){
             console.log("======================================");
-            console.log("Const Product A Term Test");
+            console.log("Const Product k=0 A Term Test");
             console.log("======================================");
             var p = new CSP();
             var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 2);
             var k = 0;
-            var product = IntegerVariable.multiplyVariableByConstant(a, k);
+            var product = IntegerVariable.multiply(a, k);
+            product.mustEqual(0);
+
+            p.testConsistency();
+            expect(new IntegerInterval(0, 2).equals(a.value())).toBe(true);
+        });
+
+        it("Integer Const Product k=0 test, reversed arguments", function(){
+            console.log("======================================");
+            console.log("Const Product k=0 Test, reversed arguments");
+            console.log("======================================");
+            var p = new CSP();
+            var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 2);
+            var k = 0;
+            var product = IntegerVariable.multiply(k, a);
+            a.mustEqual(2);
+
+            p.testConsistency();
+            assertUnique(product, 0);
+        });
+
+        it("Integer Const Product k=0 A Term test, reversed arguments", function(){
+            console.log("======================================");
+            console.log("Const Product k=0 A Term Test, reversed arguments");
+            console.log("======================================");
+            var p = new CSP();
+            var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 2);
+            var k = 0;
+            var product = IntegerVariable.multiply(k, a);
             product.mustEqual(0);
 
             p.testConsistency();
@@ -388,6 +556,65 @@ define(['inheritance', 'csp', 'floatVariable', 'integerVariable', 'mathUtil', 'i
 
             p.testConsistency();
             assertUnique(b, 1);
+        });
+
+        it("Integer Quotient Test w/ constant A term", function(){
+            console.log("======================================");
+            console.log("Quotient Test");
+            console.log("======================================");
+            var p = new CSP();
+            var a = 4;
+            var b = IntegerVariable.makeIntVariableWithBounds("b", p, 0, 2);
+            var quotent = IntegerVariable.divide(a, b);
+            b.mustEqual(2);
+
+            p.testConsistency();
+            assertUnique(quotent, 2);
+        });
+
+        it("Integer Quotent B Term Test w/ constant A term", function(){
+            console.log("======================================");
+            console.log("Quotient B Term Test");
+            console.log("======================================");
+            var p = new CSP();
+            var a = 2;
+            var b = IntegerVariable.makeIntVariableWithBounds("b", p, 0, 3);
+            var quotent = IntegerVariable.divide(a, b);
+
+            quotent.mustEqual(2);
+
+            p.testConsistency();
+            assertUnique(b, 1);
+        });
+
+        it("Integer Quotient Test w/ constant B term", function(){
+            console.log("======================================");
+            console.log("Quotient Test w/ constant B term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 4);
+            var b = 2;
+            var quotent = IntegerVariable.divide(a, b);
+
+            a.mustEqual(4);
+
+            p.testConsistency();
+            assertUnique(quotent, 2);
+        });
+
+        it("Integer Quotent A Term Test w/ constant B term", function(){
+            console.log("======================================");
+            console.log("Quotient A Term Test w/ constant B term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = IntegerVariable.makeIntVariableWithBounds("a", p, 0, 3);
+            var b = 1;
+            var quotent = IntegerVariable.divide(a, b);
+
+            quotent.mustEqual(2);
+
+            p.testConsistency();
+            assertUnique(a, 2);
         });
 
         it("Integer Odd Power Negative Test", function(){
@@ -505,6 +732,16 @@ define(['inheritance', 'csp', 'floatVariable', 'integerVariable', 'mathUtil', 'i
 
             p.testConsistency();
             expect(new IntegerInterval(-2, 2).equals(a.value())).toBe(true);
+        });
+
+        it("Integer Constant Construction Test", function(){
+          console.log("=========================================");
+          console.log("Testing Constant Construction");
+          console.log("=========================================");
+          var p = new CSP();
+          var b = IntegerVariable.makeIntConstant("b", p, 5);
+
+          expect(new IntegerInterval(5, 5).equals(b.value())).toBe(true);
         });
     });
 });

--- a/js/test/scalarArithmeticTests.js
+++ b/js/test/scalarArithmeticTests.js
@@ -131,6 +131,62 @@ define(['inheritance', 'csp', 'floatVariable', 'mathUtil', 'interval'], function
             assertUnique(b, 0.5);
         });
 
+        it("Sum Test w/ constant A term", function(){
+            console.log("======================================");
+            console.log("Sum Test w/ constant A term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = 0.5;
+            var b = FloatVariable.makeFloatVariableWithBounds("b", p, 0, 1);
+            var sum = FloatVariable.add(a, b);
+            b.mustEqual(0.25);
+
+            p.testConsistency();
+            assertUnique(sum, 0.75);
+        });
+
+        it("Sum B Term Test w/ constant A term", function(){
+            console.log("======================================");
+            console.log("Sum B Term Test w/ constant A term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = 0.5;
+            var b = FloatVariable.makeFloatVariableWithBounds("b", p, 0, 1);
+            var sum = FloatVariable.add(a, b);
+            sum.mustEqual(1);
+
+            p.testConsistency();
+            assertUnique(b, 0.5);
+        });
+
+        it("Sum Test w/ constant B term", function(){
+            console.log("======================================");
+            console.log("Sum Test");
+            console.log("======================================");
+            var p = new CSP();
+            var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 1);
+            var b = 0.25;
+            var sum = FloatVariable.add(a, b);
+            a.mustEqual(0.5);
+
+            p.testConsistency();
+            assertUnique(sum, 0.75);
+        });
+
+        it("Sum A term Test w/ constant B term", function(){
+            console.log("======================================");
+            console.log("Sum A Term Test");
+            console.log("======================================");
+            var p = new CSP();
+            var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 1);
+            var b = 0.5;
+            var sum = FloatVariable.add(a, b);
+            sum.mustEqual(1);
+
+            p.testConsistency();
+            assertUnique(a, 0.5);
+        });
+
         it("Difference Test", function(){
             console.log("======================================");
             console.log("Difference Test");
@@ -174,6 +230,62 @@ define(['inheritance', 'csp', 'floatVariable', 'mathUtil', 'interval'], function
 
             p.testConsistency();
             assertUnique(b, 0.25);
+        });
+
+        it("Difference Test w/ constant A term", function(){
+            console.log("======================================");
+            console.log("Difference Test");
+            console.log("======================================");
+            var p = new CSP();
+            var a = 0.5;
+            var b = FloatVariable.makeFloatVariableWithBounds("b", p, 0, 1);
+            var difference = FloatVariable.subtract(a, b);
+            b.mustEqual(0.25);
+
+            p.testConsistency();
+            assertUnique(difference, 0.25);
+        });
+
+        it("Difference B Term Test w/ constant A term", function(){
+            console.log("======================================");
+            console.log("Difference B Term Test");
+            console.log("======================================");
+            var p = new CSP();
+            var a = 0.5;
+            var b = FloatVariable.makeFloatVariableWithBounds("b", p, 0, 1);
+            var difference = FloatVariable.subtract(a, b);
+            difference.mustEqual(0.25);
+
+            p.testConsistency();
+            assertUnique(b, 0.25);
+        });
+
+        it("Difference Test w/ constant B term", function(){
+            console.log("======================================");
+            console.log("Difference Test w/ constant B term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 1);
+            var b = 0.25;
+            var difference = FloatVariable.subtract(a, b);
+            a.mustEqual(0.5);
+
+            p.testConsistency();
+            assertUnique(difference, 0.25);
+        });
+
+        it("Difference A Term Test w/ constant B term", function(){
+            console.log("======================================");
+            console.log("Difference A Term Test w/ constant B term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 1);
+            var b = 0.5;
+            var difference = FloatVariable.subtract(a, b);
+            difference.mustEqual(0.5);
+
+            p.testConsistency();
+            assertUnique(a, 1);
         });
 
         it("Product Test", function(){
@@ -230,7 +342,7 @@ define(['inheritance', 'csp', 'floatVariable', 'mathUtil', 'interval'], function
             var p = new CSP();
             var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 1);
             var k = 4;
-            var product = FloatVariable.multiplyVariableByConstant(a, k);
+            var product = FloatVariable.multiply(a, k);
 
             a.mustEqual(0.5);
             p.testConsistency();
@@ -244,7 +356,7 @@ define(['inheritance', 'csp', 'floatVariable', 'mathUtil', 'interval'], function
             var p = new CSP();
             var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 1);
             var k = 4;
-            var product = FloatVariable.multiplyVariableByConstant(a, k);
+            var product = FloatVariable.multiply(a, k);
             product.mustEqual(2);
 
             p.testConsistency();
@@ -258,7 +370,7 @@ define(['inheritance', 'csp', 'floatVariable', 'mathUtil', 'interval'], function
             var p = new CSP();
             var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 1);
             var k = 0;
-            var product = FloatVariable.multiplyVariableByConstant(a, k);
+            var product = FloatVariable.multiply(a, k);
             a.mustEqual(0.5);
 
             p.testConsistency();
@@ -272,7 +384,63 @@ define(['inheritance', 'csp', 'floatVariable', 'mathUtil', 'interval'], function
             var p = new CSP();
             var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 1);
             var k = 0;
-            var product = FloatVariable.multiplyVariableByConstant(a, k);
+            var product = FloatVariable.multiply(a, k);
+            product.mustEqual(0);
+
+            p.testConsistency();
+            expect(new Interval(0, 1).equals(a.value())).toBe(true);
+        });
+
+        it("Const Product Test, reversed arguments", function(){
+            console.log("======================================");
+            console.log("Const Product Test, reversed arguments");
+            console.log("======================================");
+            var p = new CSP();
+            var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 1);
+            var k = 4;
+            var product = FloatVariable.multiply(k, a);
+
+            a.mustEqual(0.5);
+            p.testConsistency();
+            assertUnique(product, 2);
+        });
+
+        it("Const Product A Term Test, reversed arguments", function(){
+            console.log("======================================");
+            console.log("Const Product A Term Test, reversed arguments");
+            console.log("======================================");
+            var p = new CSP();
+            var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 1);
+            var k = 4;
+            var product = FloatVariable.multiply(k, a);
+            product.mustEqual(2);
+
+            p.testConsistency();
+            assertUnique(a, 0.5);
+        });
+
+        it("Const Product k=0 Test, reversed arguments", function(){
+            console.log("======================================");
+            console.log("Const Product k=0 Test, reversed arguments");
+            console.log("======================================");
+            var p = new CSP();
+            var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 1);
+            var k = 0;
+            var product = FloatVariable.multiply(k, a);
+            a.mustEqual(0.5);
+
+            p.testConsistency();
+            assertUnique(product, 0);
+        });
+
+        it("Const Product k=0 A Term Test, reversed arguments", function(){
+            console.log("======================================");
+            console.log("Const Product k=0 A Term Test, reversed arguments");
+            console.log("======================================");
+            var p = new CSP();
+            var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 1);
+            var k = 0;
+            var product = FloatVariable.multiply(k, a);
             product.mustEqual(0);
 
             p.testConsistency();
@@ -325,6 +493,66 @@ define(['inheritance', 'csp', 'floatVariable', 'mathUtil', 'interval'], function
 
             p.testConsistency();
             assertUnique(b, 2);
+        });
+
+        it("Quotient Test w/ constant A term", function(){
+            console.log("======================================");
+            console.log("Quotient Test");
+            console.log("======================================");
+            var p = new CSP();
+            var a = 0.5;
+            var b = FloatVariable.makeFloatVariableWithBounds("b", p, 0, 1);
+            var quotent = FloatVariable.divide(a, b);
+
+            b.mustEqual(0.5);
+
+            p.testConsistency();
+            assertUnique(quotent, 1);
+        });
+
+        it("Quotent B Term Test w/ constant A term", function(){
+            console.log("======================================");
+            console.log("Quotient B Term Test");
+            console.log("======================================");
+            var p = new CSP();
+            var a = 0.5;
+            var b = FloatVariable.makeFloatVariableWithBounds("b", p, 0, 3);
+            var quotent = FloatVariable.divide(a, b);
+
+            quotent.mustEqual(0.25);
+
+            p.testConsistency();
+            assertUnique(b, 2);
+        });
+
+        it("Quotient Test w/ constant B term", function(){
+            console.log("======================================");
+            console.log("Quotient Test w/ constant B term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 1);
+            var b = 0.5
+            var quotent = FloatVariable.divide(a, b);
+
+            a.mustEqual(0.5);
+
+            p.testConsistency();
+            assertUnique(quotent, 1);
+        });
+
+        it("Quotent A Term Test w/ constant B term", function(){
+            console.log("======================================");
+            console.log("Quotient A Term Test w/ constant B term");
+            console.log("======================================");
+            var p = new CSP();
+            var a = FloatVariable.makeFloatVariableWithBounds("a", p, 0, 3);
+            var b = 0.5;
+            var quotent = FloatVariable.divide(a, b);
+
+            quotent.mustEqual(0.5);
+
+            p.testConsistency();
+            assertUnique(a, 0.25);
         });
 
         it("Odd Power Negative Tests", function(){
@@ -444,5 +672,14 @@ define(['inheritance', 'csp', 'floatVariable', 'mathUtil', 'interval'], function
             expect(new Interval(-2, 2).equals(a.value())).toBe(true);
         });
 
+        it("Constant Construction Test", function(){
+          console.log("=========================================");
+          console.log("Testing Sum With Constant");
+          console.log("=========================================");
+          var p = new CSP();
+          var b = FloatVariable.makeFloatConstant("b", p, 0.5);
+
+          expect(new Interval(0.5, 0.5).equals(b.value())).toBe(true);
+        });
     });
 });


### PR DESCRIPTION
Alpha version 0.22!

Added:
Interface to create constants for both `FloatVariable` and `IntegerVariable`
Type promotion on arithmetic operations-- providing Numbers to either argument automatically promotes them to a constant of the relevant variable type
Able to use GE / LE constraints with both numbers or `FloatVariable` \ `IntegerVariable` s.
